### PR TITLE
Add d1v deployment skill

### DIFF
--- a/contents/harness-extensions/skills/d1v.md
+++ b/contents/harness-extensions/skills/d1v.md
@@ -1,0 +1,7 @@
+---
+name: d1v
+link: https://github.com/d1vai/d1v-cli/tree/main/skills/d1v
+command: d1v
+---
+
+A deployment workflow skill for Claude Code and Codex that guides project deployment, waits for verified previews, and requires explicit confirmation before production releases.


### PR DESCRIPTION
## What changed

Adds the free **d1v** deployment workflow Skill to **Harness Extensions -> Agent Skills** as one metadata entry in `contents/harness-extensions/skills/d1v.md`.

## Why it fits

The official Skill is for Claude Code and Codex. It documents a deployment workflow that waits for a verified Preview terminal state and requires interactive, explicit confirmation before a Production release.

## Disclosure

I am affiliated with d1v, the maintainer of the linked resource. The linked source is public and MIT-licensed. There is no payment, sponsorship, reciprocal-link request, or expectation of acceptance; editorial review remains entirely with the maintainers.

I read `AGENTS.md` and followed the repository's one-file content structure. The public link and canonical `SKILL.md` path were verified; `git diff --check` passed. I did not run target-repository build, install, or test commands.
