### PR TITLE
Update DevProjex for v5.1

### DIFF
--- a/contents/supporting-tools/context-and-quality/devprojex.md
+++ b/contents/supporting-tools/context-and-quality/devprojex.md
@@ -3,4 +3,4 @@ name: "DevProjex"
 link: "https://github.com/Avazbek22/DevProjex"
 ---
 
-DevProjex is an open-source cross-platform GUI and CLI for selecting project files and building clean, token-counted context for AI coding workflows. It supports folder trees, file contents, Smart Ignore, preview, and multi-format export, and performs without modifying the source project.
+DevProjex is a local-first cross-platform codebase-context app with GUI, TUI, CLI, and a built-in read-only MCP server for selecting, previewing, redacting, compressing, and packing project context. It supports Smart Ignore, Git scopes, token budgets, and syntax-aware compression while keeping source projects read-only.


### PR DESCRIPTION
Updates the canonical DevProjex context tool entry to reflect the current v5.1 release. No generated site files are edited directly.