### PR TITLE
Add YYLO to Harnesses > Terminal CLIs

### DIFF
--- a/contents/harnesses/terminal-clis/yylo.md
+++ b/contents/harnesses/terminal-clis/yylo.md
@@ -1,0 +1,6 @@
+---
+name: "YYLO"
+link: "https://github.com/yylo-dev/yylo"
+---
+
+YYLO is a command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes. It wraps agent work in typed task, validation, merge, and release-readiness boundaries: task start creates a dedicated branch/worktree per task, and a merge queue owns risk-based review before anything lands. It supports quick agent loops through the Pi and Codex subagents, installs from npm as @yylo/cli (commands `yylo` and `yy`), and is MIT-licensed.


### PR DESCRIPTION
## Summary

Adds **YYLO** (`yylo-dev/yylo`) as a new tool file at `contents/harnesses/terminal-clis/yylo.md`, following the "Adding a Tool" section in the README: one new markdown file (name/link front matter + a short description), no edits to existing files.

YYLO is a command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes. Each task runs in a dedicated branch/worktree with typed task, validation, merge, and release-readiness boundaries, and a merge queue owns risk-based review before changes land. It supports quick agent loops through the Pi and Codex subagents and installs from npm as `@yylo/cli`.

## Why it fits

Terminal CLIs houses AI coding agents and the layers that orchestrate them — e.g. Parallel Code ("running multiple terminal-based coding agents in parallel … isolated git branch and worktree per task") is the closest sibling: YYLO brings the same worktree-per-task, multi-agent orchestration model to the command line, complementing Claude Code, OpenAI Codex, and OpenCode entries already in the section.

## Verification

- New file only: `+1 file`, no changes to existing tools or `_meta.md`.
- Front-matter format matches sibling files (`parallel-code.md`, `agent-qa.md`, `opencode.md`).
- Project facts: MIT-licensed, 57 stars, pushed daily since January 2026, npm `@yylo/cli`.

## Disclosure

I'm on the team that builds YYLO, and this PR was prepared with an AI coding agent following the repo's own contribution instructions. Happy to adjust the description or section if the fit is better elsewhere.