### PR TITLE
Add OrcaReplay to supporting-tools/observability

### DIFF
--- a/contents/supporting-tools/observability/orcareplay.md
+++ b/contents/supporting-tools/observability/orcareplay.md
@@ -1,0 +1,7 @@
+---
+name: "OrcaReplay"
+link: "https://github.com/Continuum-AI-Corp/OrcaReplay"
+command: "orca"
+---
+
+OrcaReplay records a coding-agent session below the harness, at the process and socket boundary, so the model traffic, the shell commands with their exit codes, the per-turn file changes and the MCP calls all land on one timeline. The recording then replays offline with the network off — the same run, byte for byte, on any machine — or forks from a chosen checkpoint onto a different model. Works with Claude Code, Codex, opencode, Qwen Code, Cursor and others, including harnesses that read no base-URL variable at all.

--- a/contents/supporting-tools/observability/orcareplay.md
+++ b/contents/supporting-tools/observability/orcareplay.md
@@ -4,4 +4,4 @@ link: "https://github.com/Continuum-AI-Corp/OrcaReplay"
 command: "orca"
 ---
 
-OrcaReplay records a coding-agent session below the harness, at the process and socket boundary, so the model traffic, the shell commands with their exit codes, the per-turn file changes and the MCP calls all land on one timeline. The recording then replays offline with the network off — the same run, byte for byte, on any machine — or forks from a chosen checkpoint onto a different model. Works with Claude Code, Codex, opencode, Qwen Code, Cursor and others, including harnesses that read no base-URL variable at all.
+OrcaReplay records a coding-agent session below the harness, at the process and socket boundary, so the model traffic, the shell commands with their exit codes, the per-turn file changes and the MCP calls all land on one timeline. The recording then replays offline with the network off, so the recorded decisions are served back rather than re-asked — or forks from a chosen checkpoint onto a different model. Works with Claude Code, Codex, opencode, Qwen Code, Cursor and others, including harnesses that read no base-URL variable at all.


### PR DESCRIPTION
Adds `contents/supporting-tools/observability/orcareplay.md`.

New file rather than an edit to an existing one, per the note in **Adding a Tool**. Frontmatter uses `name`, `link` and the optional `command`, matching the shape of the entries already in that folder.

Its neighbours there watch a session while it happens. OrcaReplay records it and then re-runs it: replay serves the recorded responses back with the network off, so a run reproduces byte-for-byte somewhere else, and fork restarts from a checkpoint on a different model with the earlier turns still served from the recording.

Apache-2.0, `npm i -g orcareplay`, Node 20+. Nine-day-old repository at 150 stars — mentioning it up front.
