### PR TITLE
Add ContextStream under context and code quality

### DIFF
--- a/contents/supporting-tools/context-and-quality/contextstream.md
+++ b/contents/supporting-tools/context-and-quality/contextstream.md
@@ -1,0 +1,6 @@
+---
+name: "ContextStream"
+link: "https://contextstream.io"
+---
+
+Shared project context for Cursor, Claude Code, Codex, and Grok. Remote MCP endpoint: https://mcp.contextstream.io/mcp. Intelligence isn’t the bottleneck. Context is.


### PR DESCRIPTION
## Summary

Adds a ContextStream page under Supporting Tools → Context & Code Quality. Separate file, as requested in Adding a Tool.

ContextStream is shared project context for Cursor, Claude Code, Codex, and Grok. Intelligence isn’t the bottleneck. Context is.

- Site: https://contextstream.io
- Remote MCP: https://mcp.contextstream.io/mcp
- Benchmarks: https://contextstream.io/benchmarks
- Open source MCP server: https://github.com/contextstream/mcp-server

Disclosure: I work on ContextStream.