### PR TITLE
Add Taskade Genesis to vibe-coding-community

### DIFF
--- a/contents/vibe-coding-community/taskade-genesis.md
+++ b/contents/vibe-coding-community/taskade-genesis.md
@@ -1,0 +1,6 @@
+---
+name: "Taskade Genesis"
+link: "https://www.taskade.com/create"
+---
+
+One prompt → live app with projects, agents, and automations.


### PR DESCRIPTION
## Summary

Adds [Taskade Genesis](https://www.taskade.com/create) as `contents/vibe-coding-community/taskade-genesis.md`, next to Lovable / v0 / YouWare.

One prompt → live app with projects, agents, and automations.

I work at Taskade.

## Test plan

- [ ] New file uses the same `name` / `link` frontmatter as neighboring community entries
- [ ] Link resolves to https://www.taskade.com/create
- [ ] Site build picks up the new community page

Made with [Cursor](https://cursor.com)